### PR TITLE
Adapt loadChartFromUri to read charts from HTTP Helm repositories

### DIFF
--- a/pkg/helmcertifier/certifier.go
+++ b/pkg/helmcertifier/certifier.go
@@ -19,7 +19,6 @@
 package helmcertifier
 
 import (
-	"github.com/pkg/errors"
 	"helmcertifier/pkg/helmcertifier/checks"
 )
 
@@ -32,11 +31,11 @@ func (e CheckNotFoundErr) Error() string {
 type CheckErr string
 
 func (e CheckErr) Error() string {
-	return "check returned error: " + string(e)
+	return "check error: " + string(e)
 }
 
 func NewCheckErr(err error) error {
-	return errors.Wrap(err, "check returned error")
+	return CheckErr(err.Error())
 }
 
 type certifier struct {

--- a/pkg/helmcertifier/certifierbuilder.go
+++ b/pkg/helmcertifier/certifierbuilder.go
@@ -50,8 +50,12 @@ func (b *certifierBuilder) Build() (Certifier, error) {
 		return nil, errors.New("no checks have been required")
 	}
 
+	if b.registry == nil {
+		b.registry = defaultRegistry
+	}
+
 	return &certifier{
-		registry:       defaultRegistry,
+		registry:       b.registry,
 		requiredChecks: b.checks,
 	}, nil
 }

--- a/pkg/helmcertifier/checks/helm.go
+++ b/pkg/helmcertifier/checks/helm.go
@@ -19,17 +19,47 @@
 package checks
 
 import (
+	"github.com/pkg/errors"
+	"io/ioutil"
+	"net/http"
 	"net/url"
 
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
 )
 
+type HTTPChartLoader struct {
+	URL *url.URL
+}
+
+func (r HTTPChartLoader) Load() (*chart.Chart, error) {
+	resp, err := http.Get(r.URL.String())
+	if err != nil {
+		return nil, err
+	}
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return nil, errors.New(string(b))
+}
+
+func NewHTTPChartLoader(url *url.URL) loader.ChartLoader {
+	return &HTTPChartLoader{URL: url}
+}
+
 func loadChartFromURI(uri string) (*chart.Chart, error) {
 	u, err := url.Parse(uri)
 	if err != nil {
 		return nil, err
 	}
-	// try to parse an `uri` string into a `URL` type to decide which `loader.Load*` function to use.
-	return loader.LoadFile(u.Path)
+
+	switch u.Scheme {
+	case "http":
+		return NewHTTPChartLoader(u).Load()
+	default:
+		// try to parse an `uri` string into a `URL` type to decide which `loader.Load*` function to use.
+		return loader.LoadFile(u.Path)
+	}
 }

--- a/pkg/helmcertifier/checks/helm_test.go
+++ b/pkg/helmcertifier/checks/helm_test.go
@@ -101,6 +101,8 @@ func TestLoadChartFromURI(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			c, err := loadChartFromURI(tc.uri)
 			require.Error(t, err)
+			require.True(t, IsChartNotFound(err))
+			require.Equal(t, "chart not found: "+tc.uri, err.Error())
 			require.Nil(t, c)
 		})
 	}

--- a/pkg/helmcertifier/checks/helm_test.go
+++ b/pkg/helmcertifier/checks/helm_test.go
@@ -19,29 +19,74 @@
 package checks
 
 import (
+	"context"
+	"log"
+	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
 
+var chartHandler = http.NotFoundHandler()
+
+func serveCharts(ctx context.Context, addr string) {
+
+	mux := http.NewServeMux()
+	mux.Handle("/charts/", chartHandler)
+
+	srv := &http.Server{
+		Addr:    addr,
+		Handler: mux,
+	}
+
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("listen: %s\n", err)
+		}
+	}()
+
+	<-ctx.Done()
+
+	ctxShutdown, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer func() {
+		cancel()
+	}()
+
+	if err := srv.Shutdown(ctxShutdown); err != nil {
+		log.Fatalf("server shutdown failed: %s\n", err)
+	}
+}
+
 func TestLoadChartFromURI(t *testing.T) {
+	addr := "127.0.0.1:8090"
+	ctx, cancel := context.WithCancel(context.Background())
+
 	type testCase struct {
 		description string
 		uri         string
 	}
 
-	testCases := []testCase{
+	positiveCases := []testCase{
 		{
 			uri:         "chart-0.1.0-v3.valid.tgz",
 			description: "absolute path",
 		},
+		{
+			uri:         "http://" + addr + "/charts/chart-0.1.0-v3.valid.tgz",
+			description: "remote path, http",
+		},
 	}
 
-	for _, tc := range testCases {
+	go serveCharts(ctx, addr)
+
+	for _, tc := range positiveCases {
 		t.Run(tc.description, func(t *testing.T) {
 			c, err := loadChartFromURI(tc.uri)
 			require.NoError(t, err)
 			require.NotNil(t, c)
 		})
 	}
+
+	cancel()
 }

--- a/pkg/helmcertifier/checks/helm_test.go
+++ b/pkg/helmcertifier/checks/helm_test.go
@@ -28,12 +28,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var chartHandler = http.NotFoundHandler()
-
 func serveCharts(ctx context.Context, addr string) {
 
 	mux := http.NewServeMux()
-	mux.Handle("/charts/", chartHandler)
+	prefix := "/charts/"
+	chartHandler := http.StripPrefix(prefix, http.FileServer(http.Dir("./")))
+	mux.Handle(prefix, chartHandler)
 
 	srv := &http.Server{
 		Addr:    addr,
@@ -59,7 +59,7 @@ func serveCharts(ctx context.Context, addr string) {
 }
 
 func TestLoadChartFromURI(t *testing.T) {
-	addr := "127.0.0.1:8090"
+	addr := "127.0.0.1:9876"
 	ctx, cancel := context.WithCancel(context.Background())
 
 	type testCase struct {

--- a/pkg/helmcertifier/checks/registry.go
+++ b/pkg/helmcertifier/checks/registry.go
@@ -43,5 +43,5 @@ func (r *defaultRegistry) Get(name string) (CheckFunc, bool) {
 
 func (r *defaultRegistry) Add(name string, checkFunc CheckFunc) Registry {
 	(*r)[name] = checkFunc
-	return nil
+	return r
 }


### PR DESCRIPTION
This change list adds the ability of reading remote charts to `loadChartFromUri`.

It also adds a function to the test infrastructure to create a HTTP server locally to serve charts to cover simple remote loading that can be used for other tests as well.