### PR TITLE
Add output format support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The following checks are being implemented:
 |---|---
 | `is-helm-v3` | Checks whether the given `uri` is a Helm v3 chart.
 | `has-readme` | Checks whether the Helm chart contains a `README.md` file.
-| `contains-tests` | Checks whether the Helm chart contains at least one test file.
+| `contains-test` | Checks whether the Helm chart contains at least one test file.
 | `readme-contains-values-schema` | Checks whether the Helm chart `README.md` file contains a `values` schema section.
 | `keywords-are-openshift-categories` | Checks whether the Helm chart's `Chart.yaml` file includes keywords mapped to OpenShift categories.
 | `is-commercial-chart` | Checks whether the Helm chart is a Commercial chart.

--- a/cmd/certify.go
+++ b/cmd/certify.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 
 	"helmcertifier/pkg/helmcertifier"
 )
@@ -75,6 +76,14 @@ func NewCertifyCmd() *cobra.Command {
 
 			if outputFormat == "json" {
 				b, err := json.Marshal(result)
+				if err != nil {
+					return err
+				}
+
+				cmd.Println(string(b))
+
+			} else if outputFormat == "yaml" {
+				b, err := yaml.Marshal(result)
 				if err != nil {
 					return err
 				}

--- a/cmd/certify.go
+++ b/cmd/certify.go
@@ -90,7 +90,7 @@ func NewCertifyCmd() *cobra.Command {
 
 				cmd.Println(string(b))
 			} else {
-				cmd.Println(result)
+				cmd.Print(result)
 			}
 
 			return nil

--- a/cmd/certify.go
+++ b/cmd/certify.go
@@ -26,7 +26,7 @@ import (
 //goland:noinspection GoUnusedGlobalVariable
 var (
 	// allChecks contains all available checks to be executed by the program.
-	allChecks []string = []string{"is-helm-package"}
+	allChecks []string = []string{"is-helm-v3"}
 	// chartUri contains the chart location as informed by the user; should accept anything that Helm understands as a Chart
 	// URI.
 	chartUri string

--- a/cmd/certify.go
+++ b/cmd/certify.go
@@ -19,7 +19,10 @@
 package cmd
 
 import (
+	"encoding/json"
+
 	"github.com/spf13/cobra"
+
 	"helmcertifier/pkg/helmcertifier"
 )
 
@@ -71,7 +74,12 @@ func NewCertifyCmd() *cobra.Command {
 			}
 
 			if outputFormat == "json" {
-				cmd.Println("{}")
+				b, err := json.Marshal(result)
+				if err != nil {
+					return err
+				}
+
+				cmd.Println(string(b))
 			} else {
 				cmd.Println(result)
 			}
@@ -87,7 +95,7 @@ func NewCertifyCmd() *cobra.Command {
 
 	cmd.Flags().StringSliceVarP(&exceptChecks, "except", "e", nil, "all available checks except those informed will be performed")
 
-	cmd.Flags().StringVarP(&outputFormat, "output", "f", "", "")
+	cmd.Flags().StringVarP(&outputFormat, "output", "f", "", "the output format: default, json or yaml")
 
 	return cmd
 }

--- a/cmd/certify.go
+++ b/cmd/certify.go
@@ -29,7 +29,7 @@ import (
 //goland:noinspection GoUnusedGlobalVariable
 var (
 	// allChecks contains all available checks to be executed by the program.
-	allChecks []string = []string{"is-helm-v3"}
+	allChecks []string = []string{"is-helm-v3", "contains-test"}
 	// chartUri contains the chart location as informed by the user; should accept anything that Helm understands as a Chart
 	// URI.
 	chartUri string

--- a/cmd/certify.go
+++ b/cmd/certify.go
@@ -34,6 +34,8 @@ var (
 	onlyChecks []string
 	// exceptChecks are the checks that should not be performed.
 	exceptChecks []string
+	// outputFormat contains the output format the user has specified: default, yaml or json.
+	outputFormat string
 )
 
 func buildChecks(allChecks, onlyChecks, _ []string) []string {
@@ -67,7 +69,12 @@ func NewCertifyCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			cmd.Println(result)
+
+			if outputFormat == "json" {
+				cmd.Println("{}")
+			} else {
+				cmd.Println(result)
+			}
 
 			return nil
 		},
@@ -79,6 +86,8 @@ func NewCertifyCmd() *cobra.Command {
 	cmd.Flags().StringSliceVarP(&onlyChecks, "only", "o", nil, "only the informed checks will be performed")
 
 	cmd.Flags().StringSliceVarP(&exceptChecks, "except", "e", nil, "all available checks except those informed will be performed")
+
+	cmd.Flags().StringVarP(&outputFormat, "output", "f", "", "")
 
 	return cmd
 }

--- a/cmd/certify_test.go
+++ b/cmd/certify_test.go
@@ -88,10 +88,22 @@ func TestCertify(t *testing.T) {
 			errBuf := bytes.NewBufferString("")
 			cmd.SetErr(errBuf)
 
-			cmd.SetArgs([]string{"-u", "../pkg/helmcertifier/checks/chart-0.1.0-v3.valid.tgz"})
+			cmd.SetArgs([]string{
+				"-u", "../pkg/helmcertifier/checks/chart-0.1.0-v3.valid.tgz",
+				"--only", "is-helm-v3", // only consider a single check, perhaps more checks in the future
+			})
 			require.NoError(t, cmd.Execute())
 			require.NotEmpty(t, outBuf.String())
-			require.Equal(t, "<CERTIFICATION OUTPUT>\n", outBuf.String())
+
+			// FIXME: the chart name inside the tarball should correspond to the tarball name
+			expected := "chart: testchart\n" +
+				"version: 1.16.0\n" +
+				"ok: true\n" +
+				"\n" +
+				"is-helm-v3:\n" +
+				"\tok: true\n" +
+				"\treason: " + checks.Helm3Reason + "\n"
+			require.Equal(t, expected, outBuf.String())
 		})
 
 		t.Run("Should display JSON certificate when flag --output and -u and values are given", func(t *testing.T) {

--- a/cmd/certify_test.go
+++ b/cmd/certify_test.go
@@ -102,20 +102,26 @@ func TestCertify(t *testing.T) {
 
 			cmd.SetArgs([]string{
 				"-u", "../pkg/helmcertifier/checks/chart-0.1.0-v3.valid.tgz",
+				"--only", "is-helm-v3",
 				"--output", "json",
 			})
 			require.NoError(t, cmd.Execute())
 			require.NotEmpty(t, outBuf.String())
 
 			expected := map[string]interface{}{
-				"chart": map[string]interface{}{
-					"name":    "chart",
-					"version": "0.1.0-v3.valid",
-				},
-				"results": map[string]interface{}{
-					"is-helm-v3": map[string]interface{}{
-						"ok":     true,
-						"reason": checks.Helm3Reason,
+				"metadata": map[string]interface{}{
+					"chart": map[string]interface{}{
+						// FIXME: the chart name inside the tarball should correspond to the tarball name
+						//"name":    "chart",
+						//"version": "0.1.0-v3.valid",
+						"name":    "testchart",
+						"version": "1.16.0",
+					},
+					"results": map[string]interface{}{
+						"is-helm-v3": map[string]interface{}{
+							"ok":     true,
+							"reason": checks.Helm3Reason,
+						},
 					},
 				},
 			}

--- a/cmd/certify_test.go
+++ b/cmd/certify_test.go
@@ -74,7 +74,9 @@ func TestCertify(t *testing.T) {
 			cmd.SetErr(errBuf)
 
 			cmd.SetArgs([]string{"-u", "/tmp/chart.tgz", "-o"})
-			require.Error(t, cmd.Execute())
+			err := cmd.Execute()
+			require.Error(t, err)
+			require.False(t, checks.IsChartNotFound(err))
 		})
 
 		t.Run("Should succeed when flag -u and values are given", func(t *testing.T) {

--- a/cmd/certify_test.go
+++ b/cmd/certify_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 
 	"helmcertifier/pkg/helmcertifier/checks"
 )
@@ -102,7 +103,7 @@ func TestCertify(t *testing.T) {
 
 			cmd.SetArgs([]string{
 				"-u", "../pkg/helmcertifier/checks/chart-0.1.0-v3.valid.tgz",
-				"--only", "is-helm-v3", // only consider a single check, perhaps more next
+				"--only", "is-helm-v3", // only consider a single check, perhaps more checks in the future
 				"--output", "json",
 			})
 			require.NoError(t, cmd.Execute())
@@ -111,6 +112,47 @@ func TestCertify(t *testing.T) {
 			// attempts to deserialize the command's output, expecting a json string
 			actual := map[string]interface{}{}
 			err := json.Unmarshal([]byte(outBuf.String()), &actual)
+			require.NoError(t, err)
+
+			expected := map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"chart": map[string]interface{}{
+						// FIXME: the chart name inside the tarball should correspond to the tarball name
+						//"name":    "chart",
+						//"version": "0.1.0-v3.valid",
+						"name":    "testchart", // should be "chart"
+						"version": "1.16.0",    // should be "0.1.0-v3.valid"
+					},
+				},
+				"ok": true,
+				"results": map[string]interface{}{
+					"is-helm-v3": map[string]interface{}{
+						"ok":     true,
+						"reason": checks.Helm3Reason,
+					},
+				},
+			}
+			require.Equal(t, expected, actual)
+		})
+
+		t.Run("Should display YAML certificate when flag --output and -u and values are given", func(t *testing.T) {
+			cmd := NewCertifyCmd()
+			outBuf := bytes.NewBufferString("")
+			cmd.SetOut(outBuf)
+			errBuf := bytes.NewBufferString("")
+			cmd.SetErr(errBuf)
+
+			cmd.SetArgs([]string{
+				"-u", "../pkg/helmcertifier/checks/chart-0.1.0-v3.valid.tgz",
+				"--only", "is-helm-v3", // only consider a single check, perhaps more checks in the future
+				"--output", "yaml",
+			})
+			require.NoError(t, cmd.Execute())
+			require.NotEmpty(t, outBuf.String())
+
+			// attempts to deserialize the command's output, expecting a json string
+			actual := map[string]interface{}{}
+			err := yaml.Unmarshal([]byte(outBuf.String()), &actual)
 			require.NoError(t, err)
 
 			expected := map[string]interface{}{

--- a/go.mod
+++ b/go.mod
@@ -8,5 +8,6 @@ require (
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/viper v1.7.0
 	github.com/stretchr/testify v1.6.1
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
 	helm.sh/helm/v3 v3.4.2
 )

--- a/hack/build.ps1
+++ b/hack/build.ps1
@@ -1,0 +1,3 @@
+$env:GOOS="windows"
+$env:GOARCH="amd64"
+go build -o helmcertifier.exe main.go

--- a/pkg/helmcertifier/certificate.go
+++ b/pkg/helmcertifier/certificate.go
@@ -64,5 +64,16 @@ func (c *certificate) IsOk() bool {
 }
 
 func (c *certificate) String() string {
-	return "<CERTIFICATION OUTPUT>"
+	report := "chart: " + c.Metadata.ChartMetadata.Name + "\n" +
+		"version: " + c.Metadata.ChartMetadata.Version + "\n" +
+		"ok: " + strconv.FormatBool(c.Ok) + "\n" +
+		"\n"
+
+	for k, v := range c.CheckResultMap {
+		report += k + ":\n" +
+			"\tok: " + strconv.FormatBool(v.Ok) + "\n" +
+			"\treason: " + v.Reason + "\n"
+	}
+
+	return report
 }

--- a/pkg/helmcertifier/certificate.go
+++ b/pkg/helmcertifier/certificate.go
@@ -18,17 +18,13 @@
 
 package helmcertifier
 
-import (
-	"encoding/json"
-)
-
 type chartMetadata struct {
-	Name    string
-	Version string
+	Name    string `json:"name"`
+	Version string `json:"version"`
 }
 
 type metadata struct {
-	ChartMetadata chartMetadata
+	ChartMetadata chartMetadata `json:"chart"`
 }
 
 func newMetadata(name, version string) *metadata {
@@ -41,9 +37,9 @@ func newMetadata(name, version string) *metadata {
 }
 
 type certificate struct {
-	Ok             bool
-	Metadata       *metadata
-	CheckResultMap checkResultMap
+	Ok             bool           `json:"ok"`
+	Metadata       *metadata      `json:"metadata"`
+	CheckResultMap checkResultMap `json:"results"`
 }
 
 type checkResultMap map[string]checkResult
@@ -51,19 +47,6 @@ type checkResultMap map[string]checkResult
 type checkResult struct {
 	Ok     bool   `json:"ok"`
 	Reason string `json:"reason"`
-}
-
-func (c *certificate) MarshalJSON() ([]byte, error) {
-	m := map[string]interface{}{
-		"metadata": map[string]interface{}{
-			"chart": map[string]interface{}{
-				"name":    c.Metadata.ChartMetadata.Name,
-				"version": c.Metadata.ChartMetadata.Version,
-			},
-			"results": c.CheckResultMap,
-		},
-	}
-	return json.Marshal(m)
 }
 
 func newCertificate(name, version string, ok bool, resultMap checkResultMap) Certificate {

--- a/pkg/helmcertifier/certificate.go
+++ b/pkg/helmcertifier/certificate.go
@@ -18,13 +18,15 @@
 
 package helmcertifier
 
+import "strconv"
+
 type chartMetadata struct {
-	Name    string `json:"name"`
-	Version string `json:"version"`
+	Name    string `json:"name" yaml:"name"`
+	Version string `json:"version" yaml:"version"`
 }
 
 type metadata struct {
-	ChartMetadata chartMetadata `json:"chart"`
+	ChartMetadata chartMetadata `json:"chart" yaml:"chart"`
 }
 
 func newMetadata(name, version string) *metadata {
@@ -37,16 +39,16 @@ func newMetadata(name, version string) *metadata {
 }
 
 type certificate struct {
-	Ok             bool           `json:"ok"`
-	Metadata       *metadata      `json:"metadata"`
-	CheckResultMap checkResultMap `json:"results"`
+	Ok             bool           `json:"ok" yaml:"ok"`
+	Metadata       *metadata      `json:"metadata" yaml:"metadata"`
+	CheckResultMap checkResultMap `json:"results" yaml:"results"`
 }
 
 type checkResultMap map[string]checkResult
 
 type checkResult struct {
-	Ok     bool   `json:"ok"`
-	Reason string `json:"reason"`
+	Ok     bool   `json:"ok" yaml:"ok"`
+	Reason string `json:"reason" yaml:"reason"`
 }
 
 func newCertificate(name, version string, ok bool, resultMap checkResultMap) Certificate {

--- a/pkg/helmcertifier/certificate.go
+++ b/pkg/helmcertifier/certificate.go
@@ -18,10 +18,40 @@
 
 package helmcertifier
 
+type chartMetadata struct {
+	Name    string
+	Version string
+}
+
+type certificateMetadata struct {
+	ChartMetadata chartMetadata
+}
+
+func newCertificateMetadata(name, version string) *certificateMetadata {
+	return &certificateMetadata{
+		ChartMetadata: chartMetadata{
+			Name:    name,
+			Version: version,
+		},
+	}
+}
+
 type certificate struct {
-	Ok bool
+	CertificateMetadata *certificateMetadata
+	Ok                  bool
+}
+
+func newCertificate(name, version string, ok bool) Certificate {
+	return &certificate{
+		CertificateMetadata: newCertificateMetadata(name, version),
+		Ok:                  ok,
+	}
 }
 
 func (r *certificate) IsOk() bool {
 	return r.Ok
+}
+
+func (r *certificate) String() string {
+	return "<CERTIFICATION OUTPUT>"
 }

--- a/pkg/helmcertifier/certifier.go
+++ b/pkg/helmcertifier/certifier.go
@@ -62,7 +62,7 @@ func (c *certifier) Certify(uri string) (Certificate, error) {
 			if err != nil {
 				return nil, NewCheckErr(err)
 			}
-			_ = result.AddResult(r)
+			_ = result.AddCheckResult(name, r)
 		}
 	}
 

--- a/pkg/helmcertifier/certifier.go
+++ b/pkg/helmcertifier/certifier.go
@@ -44,7 +44,15 @@ type certifier struct {
 }
 
 func (c *certifier) Certify(uri string) (Certificate, error) {
-	result := NewCertificateBuilder()
+
+	chrt, err := checks.LoadChartFromURI(uri)
+	if err != nil {
+		return nil, err
+	}
+
+	result := NewCertificateBuilder().
+		SetChartName(chrt.Name()).
+		SetChartVersion(chrt.AppVersion())
 
 	for _, name := range c.requiredChecks {
 		if checkFunc, ok := c.registry.Get(name); !ok {

--- a/pkg/helmcertifier/certifierbuilder.go
+++ b/pkg/helmcertifier/certifierbuilder.go
@@ -27,7 +27,7 @@ var defaultRegistry checks.Registry
 
 func init() {
 	defaultRegistry = checks.NewRegistry()
-	defaultRegistry.Add("is-helm-package", checks.IsHelmV3)
+	defaultRegistry.Add("is-helm-v3", checks.IsHelmV3)
 }
 
 type certifierBuilder struct {

--- a/pkg/helmcertifier/certifierbuilder.go
+++ b/pkg/helmcertifier/certifierbuilder.go
@@ -28,6 +28,7 @@ var defaultRegistry checks.Registry
 func init() {
 	defaultRegistry = checks.NewRegistry()
 	defaultRegistry.Add("is-helm-v3", checks.IsHelmV3)
+	defaultRegistry.Add("contains-test", checks.ContainsTest)
 }
 
 type certifierBuilder struct {

--- a/pkg/helmcertifier/checks/checks.go
+++ b/pkg/helmcertifier/checks/checks.go
@@ -75,7 +75,7 @@ func HasReadme(uri string) (Result, error) {
 }
 
 func ContainsTest(uri string) (Result, error) {
-	c, err := loadChartFromURI(uri)
+	c, err := LoadChartFromURI(uri)
 	if err != nil {
 		return Result{}, err
 	}

--- a/pkg/helmcertifier/checks/checks.go
+++ b/pkg/helmcertifier/checks/checks.go
@@ -44,7 +44,7 @@ func notImplemented() (Result, error) {
 }
 
 func IsHelmV3(uri string) (Result, error) {
-	c, err := loadChartFromURI(uri)
+	c, err := LoadChartFromURI(uri)
 	if err != nil {
 		return Result{}, err
 	}
@@ -58,7 +58,7 @@ func IsHelmV3(uri string) (Result, error) {
 }
 
 func HasReadme(uri string) (Result, error) {
-	c, err := loadChartFromURI(uri)
+	c, err := LoadChartFromURI(uri)
 	if err != nil {
 		return Result{}, err
 	}

--- a/pkg/helmcertifier/checks/helm.go
+++ b/pkg/helmcertifier/checks/helm.go
@@ -71,9 +71,9 @@ func loadChartFromAbsPath(path string) (*chart.Chart, error) {
 	return c, nil
 }
 
-// loadChartFromURI attempts to retrieve a chart from the given uri string. It accepts "http", "https", "file" schemes,
+// LoadChartFromURI attempts to retrieve a chart from the given uri string. It accepts "http", "https", "file" schemes,
 // and defaults to "file" if there isn't one.
-func loadChartFromURI(uri string) (*chart.Chart, error) {
+func LoadChartFromURI(uri string) (*chart.Chart, error) {
 	u, err := url.Parse(uri)
 	if err != nil {
 		return nil, err

--- a/pkg/helmcertifier/checks/helm_test.go
+++ b/pkg/helmcertifier/checks/helm_test.go
@@ -20,45 +20,15 @@ package checks
 
 import (
 	"context"
-	"log"
-	"net/http"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"helmcertifier/pkg/testutil"
 )
-
-// serveCharts attempts to create a simple HTTP server on the given addr.
-func serveCharts(ctx context.Context, addr string) {
-
-	mux := http.NewServeMux()
-	prefix := "/charts/"
-	chartHandler := http.StripPrefix(prefix, http.FileServer(http.Dir("./")))
-	mux.Handle(prefix, chartHandler)
-
-	srv := &http.Server{Addr: addr, Handler: mux}
-
-	go func() {
-		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			log.Fatalf("listen: %s\n", err)
-		}
-	}()
-
-	<-ctx.Done()
-
-	ctxShutdown, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer func() {
-		cancel()
-	}()
-
-	if err := srv.Shutdown(ctxShutdown); err != nil {
-		log.Fatalf("server shutdown failed: %s\n", err)
-	}
-}
 
 func TestLoadChartFromURI(t *testing.T) {
 	addr := "127.0.0.1:9876"
-	ctx, cancel := context.WithCancel(context.Background())
 
 	type testCase struct {
 		description string
@@ -87,7 +57,8 @@ func TestLoadChartFromURI(t *testing.T) {
 		},
 	}
 
-	go serveCharts(ctx, addr)
+	ctx, cancel := context.WithCancel(context.Background())
+	go testutil.ServeCharts(ctx, addr, "./")
 
 	for _, tc := range positiveCases {
 		t.Run(tc.description, func(t *testing.T) {

--- a/pkg/helmcertifier/checks/helm_test.go
+++ b/pkg/helmcertifier/checks/helm_test.go
@@ -91,7 +91,7 @@ func TestLoadChartFromURI(t *testing.T) {
 
 	for _, tc := range positiveCases {
 		t.Run(tc.description, func(t *testing.T) {
-			c, err := loadChartFromURI(tc.uri)
+			c, err := LoadChartFromURI(tc.uri)
 			require.NoError(t, err)
 			require.NotNil(t, c)
 		})
@@ -99,7 +99,7 @@ func TestLoadChartFromURI(t *testing.T) {
 
 	for _, tc := range negativeCases {
 		t.Run(tc.description, func(t *testing.T) {
-			c, err := loadChartFromURI(tc.uri)
+			c, err := LoadChartFromURI(tc.uri)
 			require.Error(t, err)
 			require.True(t, IsChartNotFound(err))
 			require.Equal(t, "chart not found: "+tc.uri, err.Error())

--- a/pkg/helmcertifier/checks/registry.go
+++ b/pkg/helmcertifier/checks/registry.go
@@ -19,6 +19,7 @@
 package checks
 
 type Result struct {
+	// Ok indicates whether the result was successful or not.
 	Ok bool
 	// Reason for the result value.  This is a message indicating
 	// the reason for the value of Ok became true or false.

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 27/01/2021, 12:51, igors
+ * This file is part of helmcertifier.
+ *
+ * helmcertifier is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * helmcertifier is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with helmcertifier.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package testutil
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"time"
+)
+
+// ServeCharts attempts to create a simple HTTP server on the given addr.
+func ServeCharts(ctx context.Context, addr string, path string) {
+	if path == "" {
+		path = "./"
+	}
+
+	mux := http.NewServeMux()
+	prefix := "/charts/"
+	chartHandler := http.StripPrefix(prefix, http.FileServer(http.Dir(path)))
+	mux.Handle(prefix, chartHandler)
+
+	srv := &http.Server{Addr: addr, Handler: mux}
+
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("listen: %s\n", err)
+		}
+	}()
+
+	<-ctx.Done()
+
+	ctxShutdown, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer func() {
+		cancel()
+	}()
+
+	if err := srv.Shutdown(ctxShutdown); err != nil {
+		log.Fatalf("server shutdown failed: %s\n", err)
+	}
+}


### PR DESCRIPTION
This change list allows the user to specify the output format the 
certificate will be presented; at first the following formats will
be available:

* `default` - the default output, will display a decent representation 
 of the certificate result.
* `yaml` - the certificate YAML encoded.
* `json` - the certificate JSON encoded.

Below there's an example how the default output looks like:
```
PS C:\Users\igors\go\src\helmcertifier> .\helmcertifier.exe certify -u .\pkg\helmcertifier\checks\chart-0.1.0-v3.valid.tgz
chart: testchart
version: 1.16.0
ok: true

is-helm-v3:
        ok: true
        reason: API version is V2 used in Helm 3
contains-test:
        ok: true
        reason: Chart test files exist
```

Below there's an example of what the `json` output looks like:
```
PS C:\Users\igors\go\src\helmcertifier> .\helmcertifier.exe certify -u .\pkg\helmcertifier\checks\chart-0.1.0-v3.valid.tgz --output json
{"ok":true,"metadata":{"chart":{"name":"testchart","version":"1.16.0"}},"results":{"contains-test":{"ok":true,"reason":"Chart test files exist"},"is-helm-v3":{"ok":true,"reason":"API version is V2 used in Helm 3"}}}
```

Below there's an example of what the `yaml` output looks like:
```
PS C:\Users\igors\go\src\helmcertifier> .\helmcertifier.exe certify -u .\pkg\helmcertifier\checks\chart-0.1.0-v3.valid.tgz --output yaml
ok: true
metadata:
    chart:
        name: testchart
        version: 1.16.0
results:
    contains-test:
        ok: true
        reason: Chart test files exist
    is-helm-v3:
        ok: true
        reason: API version is V2 used in Helm 3
```

