### PR TITLE
Create Dockerfile to build the container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM golang:1.15 AS build
+
+WORKDIR /tmp/src
+
+COPY go.mod .
+COPY go.sum .
+
+RUN go mod download
+
+COPY . .
+
+RUN ./hack/build.sh
+
+FROM fedora:31
+
+COPY --from=build /tmp/src/out/helmcertifier /app/helmcertifier
+
+ENTRYPOINT ["/app/helmcertifier"]

--- a/README.md
+++ b/README.md
@@ -56,14 +56,14 @@ To certify a chart against all available checks:
 > helmcertifier --uri https://www.example.com/chart.tgz
 ```
 
-To apply only the `is-helm-chart` check:
+To apply only the `is-helm-v3` check:
 
 ```text
-> helmcertifier --only is-helm-chart --uri https://www.example.com/chart.tgz
+> helmcertifier --only is-helm-v3 --uri https://www.example.com/chart.tgz
 ```
 
-To apply all checks except `is-helm-chart`:
+To apply all checks except `is-helm-v3`:
 
 ```text
-> helmcertifier --except is-helm-chart --uri https://www.example.com/chart.tgz
+> helmcertifier --except is-helm-v3 --uri https://www.example.com/chart.tgz
 ```

--- a/cmd/certify.go
+++ b/cmd/certify.go
@@ -27,10 +27,14 @@ import (
 	"helmcertifier/pkg/helmcertifier"
 )
 
+func init() {
+	allChecks = helmcertifier.DefaultRegistry().AllChecks()
+}
+
 //goland:noinspection GoUnusedGlobalVariable
 var (
 	// allChecks contains all available checks to be executed by the program.
-	allChecks []string = []string{"is-helm-v3", "contains-test"}
+	allChecks []string
 	// chartUri contains the chart location as informed by the user; should accept anything that Helm understands as a Chart
 	// URI.
 	chartUri string

--- a/hack/build-image.ps1
+++ b/hack/build-image.ps1
@@ -1,0 +1,2 @@
+$COMMIT_ID = $(git rev-parse --short HEAD)
+docker build -t helmcertifier:$COMMIT_ID .

--- a/hack/build-image.sh
+++ b/hack/build-image.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 31/01/2021, 13:04, igors
+# This file is part of helmcertifier.
+#
+# helmcertifier is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# helmcertifier is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with helmcertifier.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+COMMIT_ID=$(git rev-parse --short HEAD)
+docker build -t helmcertifier:"$COMMIT_ID" .

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 31/01/2021, 12:51, igors
+# This file is part of helmcertifier.
+#
+# helmcertifier is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# helmcertifier is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with helmcertifier.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+go build -o ./out/helmcertifier main.go

--- a/pkg/helmcertifier/certifierbuilder.go
+++ b/pkg/helmcertifier/certifierbuilder.go
@@ -20,6 +20,7 @@ package helmcertifier
 
 import (
 	"errors"
+
 	"helmcertifier/pkg/helmcertifier/checks"
 )
 
@@ -29,6 +30,13 @@ func init() {
 	defaultRegistry = checks.NewRegistry()
 	defaultRegistry.Add("is-helm-v3", checks.IsHelmV3)
 	defaultRegistry.Add("contains-test", checks.ContainsTest)
+	defaultRegistry.Add("contains-values", checks.ContainsValues)
+	defaultRegistry.Add("contains-values-schema", checks.ContainsValuesSchema)
+	defaultRegistry.Add("has-minkubeversion", checks.HasMinKubeVersion)
+}
+
+func DefaultRegistry() checks.Registry {
+	return defaultRegistry
 }
 
 type certifierBuilder struct {

--- a/pkg/helmcertifier/checks/registry.go
+++ b/pkg/helmcertifier/checks/registry.go
@@ -31,9 +31,18 @@ type CheckFunc func(uri string) (Result, error)
 type Registry interface {
 	Get(name string) (CheckFunc, bool)
 	Add(name string, checkFunc CheckFunc) Registry
+	AllChecks() []string
 }
 
 type defaultRegistry map[string]CheckFunc
+
+func (r *defaultRegistry) AllChecks() []string {
+	allChecks := make([]string, 0)
+	for k, _ := range *r {
+		allChecks = append(allChecks, k)
+	}
+	return allChecks
+}
 
 func NewRegistry() Registry {
 	return &defaultRegistry{}


### PR DESCRIPTION
This change list creates a Dockerfile to build the container image with the CLI.

Build scripts have been included in the `hack` directory: `build-image.sh` and `build.sh` (in addition to PowerShell equivalents for development purposes), and a multi-stage Dockerfile resulting in an image with the compiled command.

Below it is possible to see the CLI being executed with `docker run` against a test chart being stored in GitHub:
```
PS C:\Users\igors\go\src\helmcertifier> docker run -it helmcertifier:55f538f certify -u https://github.com/isutton/helmcertifier/blob/master/pkg/helmcertifier/checks/chart
-0.1.0-v3.valid.tgz?raw=true
chart: testchart
version: 1.16.0
ok: true

contains-values-schema:
        ok: true
        reason: Values schema file exist
has-minkubeversion:
        ok: true
        reason: Minimum Kubernetes version specified
is-helm-v3:
        ok: true
        reason: API version is V2 used in Helm 3
contains-test:
        ok: true
        reason: Chart test files exist
contains-values:
        ok: true
        reason: Values file exist
```

Below there's an example with the container image verifying a chart stored in the host:

```
PS C:\Users\igors\go\src\helmcertifier> docker run -it -v "C:\Users\igors\go\src\helmcertifier\pkg\helmcertifier\checks:/charts" helmcertifier:55f538f certify -u /charts/c
hart-0.1.0-v3.valid.tgz     
chart: testchart
version: 1.16.0
ok: true

has-minkubeversion:
        ok: true
        reason: Minimum Kubernetes version specified
is-helm-v3:
        ok: true
        reason: API version is V2 used in Helm 3
contains-test:
        ok: true
        reason: Chart test files exist
contains-values:
        ok: true
        reason: Values file exist
contains-values-schema:
        ok: true
        reason: Values schema file exist
```

Example of `yaml` output:

```
PS C:\Users\igors\go\src\helmcertifier> docker run -it -v "C:\Users\igors\go\src\helmcertifier\pkg\helmcertifier\checks:/charts" helmcertifier:55f538f certify -u /charts/c
hart-0.1.0-v3.valid.tgz --output yaml
ok: true
metadata:
    chart:
        name: testchart
        version: 1.16.0
results:
    contains-test:
        ok: true
        reason: Chart test files exist
    contains-values:
        ok: true
        reason: Values file exist
    contains-values-schema:
        ok: true
        reason: Values schema file exist
    has-minkubeversion:
        ok: true
        reason: Minimum Kubernetes version specified
    is-helm-v3:
        ok: true
        reason: API version is V2 used in Helm 3

```

And also `json` output (the output isn't beautified as of yet):

```
PS C:\Users\igors\go\src\helmcertifier> docker run -it -v "C:\Users\igors\go\src\helmcertifier\pkg\helmcertifier\checks:/charts" helmcertifier:55f538f certify -u /charts/c
hart-0.1.0-v3.valid.tgz --output json
{"ok":true,"metadata":{"chart":{"name":"testchart","version":"1.16.0"}},"results":{"contains-test":{"ok":true,"reason":"Chart test files exist"},"contains-values":{"ok":tr
ue,"reason":"Values file exist"},"contains-values-schema":{"ok":true,"reason":"Values schema file exist"},"has-minkubeversion":{"ok":true,"reason":"Minimum Kubernetes vers
ion specified"},"is-helm-v3":{"ok":true,"reason":"API version is V2 used in Helm 3"}}}
```